### PR TITLE
Fix: withLogger doesn't work when cause consume error

### DIFF
--- a/delayqueue.go
+++ b/delayqueue.go
@@ -764,7 +764,7 @@ func (q *DelayQueue) StartConsume() (done <-chan struct{}) {
 			case <-q.ticker.C:
 				ids, err := q.beforeConsume()
 				if err != nil {
-					log.Printf("consume error: %v", err)
+					q.logger.Printf("consume error: %v", err)
 				}
 				q.goWithRecover(func() {
 					for _, id := range ids {


### PR DESCRIPTION
withLogger doesn't work when cause consume error in delayqueue.go:767 [delayqueue.go](https://github.com/HDT3213/delayqueue/blob/7816eb01de2cbc9b6d0a0b27c84344b39f5d3f4b/delayqueue.go#L767)