### PR TITLE
Fix: respect nackRedeliveryDelay after queue restart

### DIFF
--- a/delayqueue.go
+++ b/delayqueue.go
@@ -473,6 +473,14 @@ func (q *DelayQueue) ready2Unack() (string, error) {
 
 func (q *DelayQueue) retry2Unack() (string, error) {
 	retryTime := time.Now().Add(q.maxConsumeDuration).Unix()
+	// If nackRedeliveryDelay is set, use the later time to ensure
+	// messages from retry queue respect the original nack delay
+	if q.nackRedeliveryDelay > 0 {
+		nackRetryTime := time.Now().Add(q.nackRedeliveryDelay).Unix()
+		if nackRetryTime > retryTime {
+			retryTime = nackRetryTime
+		}
+	}
 	keys := []string{q.retryKey, q.unAckKey}
 	ret, err := q.eval(ready2UnackScript, keys, []interface{}{retryTime, q.retryKey, q.unAckKey})
 	if err == NilErr {


### PR DESCRIPTION
## Summary
- Fixed an issue where `nackRedeliveryDelay` was not respected after queue restart
- Messages that were nacked with a delay were being consumed immediately upon restart

## Problem
As reported in #16, when `WithNackRedeliveryDelay(time.Second * 2)` is configured and the service restarts, messages are consumed immediately instead of waiting for the configured delay.

The issue occurs because `retry2Unack()` was only considering `maxConsumeDuration` when moving messages from retry queue to unack queue, ignoring the `nackRedeliveryDelay` setting.

## Solution
Modified `retry2Unack()` to use the later of `maxConsumeDuration` or `nackRedeliveryDelay` when setting the retry time for messages being moved from retry to unack state.

## Test plan
- [x] Added `TestDelayQueue_NackRedeliveryDelayAfterRestart` to verify the fix
- [x] Test simulates a queue restart and verifies messages respect the delay
- [x] Fixed syntax error in `monitor_test.go` (unrelated but found during testing)

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)