### PR TITLE
修复：重启后正确遵守 nackRedeliveryDelay

### DIFF
--- a/delayqueue.go
+++ b/delayqueue.go
@@ -473,6 +473,14 @@ func (q *DelayQueue) ready2Unack() (string, error) {
 
 func (q *DelayQueue) retry2Unack() (string, error) {
 	retryTime := time.Now().Add(q.maxConsumeDuration).Unix()
+	// If nackRedeliveryDelay is set, use the later time to ensure
+	// messages from retry queue respect the original nack delay
+	if q.nackRedeliveryDelay > 0 {
+		nackRetryTime := time.Now().Add(q.nackRedeliveryDelay).Unix()
+		if nackRetryTime > retryTime {
+			retryTime = nackRetryTime
+		}
+	}
 	keys := []string{q.retryKey, q.unAckKey}
 	ret, err := q.eval(ready2UnackScript, keys, []interface{}{retryTime, q.retryKey, q.unAckKey})
 	if err == NilErr {


### PR DESCRIPTION
## 问题描述

修复 Issue #16 中描述的问题：当设置了 `WithNackRedeliveryDelay(time.Second * 2)` 时，如果消息被 nack 后服务重启，消息会立即被重新消费，而不是等待设定的延迟时间。

## 根本原因

问题出现在 `retry2Unack()` 函数中：
- 当消息被 nack 时，会在 `unAckKey` 中设置未来的重试时间
- 服务重启后，`unack2Retry()` 会将过期的消息移动到 `retryKey`
- `retry2Unack()` 从 `retryKey` 取出消息放入 `unAckKey` 时，只考虑了 `maxConsumeDuration`
- **忽略了原始的 `nackRedeliveryDelay` 设置**，导致消息立即可用

## 解决方案

修改 `retry2Unack()` 函数，使用 `max(maxConsumeDuration, nackRedeliveryDelay)` 作为重试时间：

```go
func (q *DelayQueue) retry2Unack() (string, error) {
    retryTime := time.Now().Add(q.maxConsumeDuration).Unix()
    // 如果设置了 nackRedeliveryDelay，使用更长的时间
    // 确保从 retry 队列的消息遵守原始的 nack 延迟
    if q.nackRedeliveryDelay > 0 {
        nackRetryTime := time.Now().Add(q.nackRedeliveryDelay).Unix()
        if nackRetryTime > retryTime {
            retryTime = nackRetryTime
        }
    }
    // ... 后续代码
}
```

## 测试验证

添加了 `TestDelayQueue_Issue16_RestartScenario` 测试用例，完整模拟重启场景：
1. 消息被消费并 nack，设置延迟
2. 等待延迟过期，消息进入 retry 队列
3. 模拟重启创建新队列实例
4. 验证消息遵守 `nackRedeliveryDelay` 而不是立即消费

## 影响范围

- ✅ 修复了重启后 nackRedeliveryDelay 不生效的问题
- ✅ 保持向后兼容性，不影响现有功能
- ✅ 仅在设置了 nackRedeliveryDelay 时生效

## 测试计划

```bash
# 运行特定测试验证修复
go test -v -run TestDelayQueue_Issue16_RestartScenario

# 运行所有相关测试确保无回归
go test -v -run TestDelayQueue_NackRedeliveryDelay
```

修复 #16